### PR TITLE
Lower python version required

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,9 @@ build:
 requirements:
   host:
     - pip
-    - python >=3
+    - python >=2.7
   run:
-    - python >=3
+    - python >=2.7
 
 test:
   imports:


### PR DESCRIPTION
pyaaf2 still supports python2.7, so it makes sense to lower the required python version to 2.7.
